### PR TITLE
Add python binding (pycorels)

### DIFF
--- a/pycorels/README.md
+++ b/pycorels/README.md
@@ -1,0 +1,85 @@
+# Python binding of CORELS
+
+## Installation
+
+First, go to the src/ directory and run `make libcorels.so`
+
+Then, copy the generated file (libcorels.so) into some directory included in
+your linker search path (such as /usr/local/lib on Linux).
+
+Then, run `python setup.py install` or `python3 setup.py install` in this directory
+(pycorels) depending on what version of python you wish to use pycorels with.
+
+## Usage
+
+First, you have to include the module:
+`import pycorels`
+
+There are currently only three functions in the module: `pycorels.run`, `pycorels.tolist`, and `pycorels.tofile`
+
+### pycorels.run
+
+#### Parameters
+
+`pycorels.run` is the most important function, which runs the actual algorithm. Its usage is as follows:
+
+`pycorels.run(out_file, label_file, [keywords])`
+
+Where out_file and label_file can either be file paths (strings) or a list
+of tuples, where each tuple contains two elements, the first being a string
+for the rule features and the second being a numpy array of ints or bools
+of length nsamples, representing the captured bitvector of each rule.
+
+The optional keywords are:
+
+| Keywords                          | Description 
+| ---                               | ---
+| minor_data (string or list)       | minority info, either in a file path or list
+| opt_file (string)                 | the path of the file in which to store the optimal rule list, defaults to "corels-opt.txt"
+| log_file (string)                 | the path of the log file, defaults to "corels.txt"
+| curiosity_policy (integer)        | the method of ordering the queue elements, valid values are between 0 and 4, inclusive, which correspond to ordering by BFS, curiosity, lower bound, objective, and dfs, respecively
+| latex_out (string)                | the path of the file in which to store the output in latex format. Defaults to blank (and no file is outputted unless a path is given)
+| map_type (integer)                | the type of symmetry-aware map to use, valid values are between 0 and 2, inclusive, with 0 being no map, 1 being prefix permutation map, and 2 being captured permutation map
+| verbosity (string)                | a comma-separated list of verbosity tags, valid tags are 'rule', 'label', 'samples', 'progress', 'log', and 'silent'
+| log_freq (integer)                |  every this number of nodes searched in the queue, print an update in the log
+| max_num_nodes (integer)           | maximum number of nodes to be searched before exiting
+| c (float)                         | regularization constant
+| ablation (integer)                | dictates what kind of bounds to use (greater than 1 uses the lower bound on antecedent bound, and greater than 2 uses the lookahead bound)
+| calculate_size (bool)             | whether or not the logger should keep track of memory usage
+
+#### Return value
+
+Currently, pycorels.run returns none
+
+
+### pycorels.tolist
+
+#### Parameters
+
+This function only takes one required argument: a string for the path to
+the rule file
+
+#### Return value
+
+returns a list of tuples (in the format detailed above) describing the rules, not containing a default rule
+
+### pycorels.tofile
+
+#### Parameters
+
+This function only takes two required arguments: the first is a list of tuples describing a list of rules (as specified above), and the second is a path to a file. The function then outputs the list into the file specified by the second argument, the exact opposite of pycorels.tolist.
+
+#### Return value
+
+None
+
+
+## Example
+
+~~~~
+import pycorels
+
+pycorels.run("../data/bcancer.out", "../data/bcancer.label", verbosity="progress,samples", max_num_nodes=1000000)
+
+out_list = pycorels.tolist("../data/bcancer.out")
+~~~~

--- a/pycorels/pycorels.c
+++ b/pycorels/pycorels.c
@@ -1,0 +1,355 @@
+#include <Python.h>
+#include <string.h>
+
+#define NPY_NO_DEPRECATED_API NPY_API_VERSION
+
+#include <numpy/arrayobject.h>
+
+#include "../src/run.hh"
+
+#include "../src/rule.h"
+
+#include "utils.h"
+
+static PyObject *pycorels_tofile(PyObject *self, PyObject *args)
+{
+    PyObject *list;
+    const char *fname;
+
+    if(!PyArg_ParseTuple(args, "Os", &list, &fname))
+        return NULL;
+
+    if(!PyList_Check(list)) {
+        PyErr_SetString(PyExc_TypeError, "Argument must be a list");
+        return NULL;
+    }
+
+    PyObject *tuple, *vector;
+    char *features;
+
+    npy_intp list_len = PyList_Size(list);
+
+    FILE *fp;
+    if(!(fp = fopen(fname, "w")))
+        return NULL;
+
+    for(Py_ssize_t i = 0; i < list_len; i++) {
+        if(!(tuple = PyList_GetItem(list, i)))
+            goto error;
+
+        if(!PyTuple_Check(tuple)) {
+            PyErr_SetString(PyExc_TypeError, "Array members must be tuples");
+            goto error;
+        }
+
+        if(!PyArg_ParseTuple(tuple, "sO", &features, &vector))
+            goto error;
+
+        fprintf(fp, "%s ", features);
+
+        int type = PyArray_TYPE((PyArrayObject*)vector);
+        if(PyArray_NDIM((PyArrayObject*)vector) != 1 && (PyTypeNum_ISINTEGER(type) || PyTypeNum_ISBOOL(type))) {
+            PyErr_SetString(PyExc_TypeError, "Each rule truthable must be a 1-d array of integers or booleans");
+            goto error;
+        }
+
+        PyArrayObject *clean = (PyArrayObject*)PyArray_FromAny(vector, PyArray_DescrFromType(NPY_BYTE), 0, 0, NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY | NPY_ARRAY_FORCECAST, NULL);
+        if(clean == NULL) {
+            PyErr_SetString(PyExc_Exception, "Could not cast array to byte carray");
+            goto error;
+        }
+
+        char *data = PyArray_BYTES(clean);
+        npy_intp b_len = PyArray_SIZE(clean);
+
+        for(npy_intp j = 0; j < b_len-1; j++) {
+            fprintf(fp, "%d ", !!data[j]);
+        }
+
+        fprintf(fp, "%d\n", !!data[b_len-1]);
+
+        Py_DECREF(clean);
+    }
+
+    fclose(fp);
+
+    Py_INCREF(Py_None);
+    return Py_None;
+
+error:
+    fclose(fp);
+    return NULL;
+}
+
+static PyObject *pycorels_tolist(PyObject *self, PyObject *args)
+{
+    const char *fname;
+
+    if(!PyArg_ParseTuple(args, "s", &fname))
+        return NULL;
+
+    rule_t *rules;
+    int nrules, nsamples;
+
+    if(rules_init(fname, &nrules, &nsamples, &rules, 0) != 0) {
+        PyErr_SetString(PyExc_ValueError, "Could not load rule file");
+        return NULL;
+    }
+
+    PyObject *list = PyList_New(nrules);
+
+    PyObject *res = fill_list(list, rules, 0, nrules, nsamples);
+    if(!res) {
+        Py_XDECREF(list);
+        list = NULL;
+    }
+
+    rules_free(rules, nrules, 0);
+
+    return list;
+}
+
+static PyObject* pycorels_run(PyObject* self, PyObject* args, PyObject* keywds)
+{
+    PyObject* out_data;
+    char* out_fname = NULL;
+
+    PyObject* label_data;
+    char* label_fname = NULL;
+
+    PyObject* minor_data = NULL;
+    char* minor_fname = NULL;
+
+    run_params_t params;
+    set_default_params(&params);
+
+    static char* kwlist[] = {"out_data", "label_data", "minor_data", "opt_file", "log_file", "curiosity_policy", "latex_out", "map_type",
+                             "verbosity", "log_freq", "max_num_nodes", "c", "ablation", "calculate_size"};
+
+    if(!PyArg_ParseTupleAndKeywords(args, keywds, "OO|Ossibisiidibb", kwlist, &out_data, &label_data, &minor_data,
+                                    &params.opt_fname, &params.log_fname, &params.curiosity_policy, &params.latex_out, &params.map_type, &params.vstring,
+                                    &params.freq, &params.max_num_nodes, &params.c, &params.ablation, &params.calculate_size))
+    {
+        return NULL;
+    }
+
+    char error_txt[BUFSZ];
+    PyObject* error_type = PyExc_ValueError;
+
+    if(PyBytes_Check(out_data)) {
+        if(!(out_fname = strdup(PyBytes_AsString(out_data))))
+            return NULL;
+    }
+    else if(PyUnicode_Check(out_data)) {
+        PyObject* bytes = PyUnicode_AsUTF8String(out_data);
+        if(!bytes)
+            return NULL;
+
+        else if(!(out_fname = strdup(PyBytes_AsString(bytes))))
+            return NULL;
+
+        Py_DECREF(bytes);
+    }
+    else if(PyList_Check(out_data)) {
+        if(!PyList_Size(out_data)) {
+            snprintf(error_txt, BUFSZ, "out list must be non-empty");
+            goto error;
+        }
+    }
+    else {
+        snprintf(error_txt, BUFSZ, "out data must be either a python list or a file path");
+        error_type = PyExc_TypeError;
+        goto error;
+    }
+
+    if(PyBytes_Check(label_data)) {
+        if(!(label_fname = strdup(PyBytes_AsString(label_data))))
+            return NULL;
+    }
+    else if(PyUnicode_Check(label_data)) {
+        PyObject* bytes = PyUnicode_AsUTF8String(label_data);
+        if(!bytes)
+            return NULL;
+
+        else if(!(label_fname = strdup(PyBytes_AsString(bytes))))
+            return NULL;
+
+        Py_DECREF(bytes);
+    }
+    else if(PyList_Check(label_data)) {
+        if(!PyList_Size(label_data)) {
+            snprintf(error_txt, BUFSZ, "label list must be non-empty");
+            goto error;
+        }
+    }
+    else {
+        snprintf(error_txt, BUFSZ, "label data must be either a python list or a file path");
+        error_type = PyExc_TypeError;
+        goto error;
+    }
+
+    if(minor_data) {
+        if(PyBytes_Check(minor_data)) {
+            if(!(minor_fname = strdup(PyBytes_AsString(minor_data))))
+                return NULL;
+        }
+        else if(PyUnicode_Check(minor_data)) {
+            PyObject* bytes = PyUnicode_AsUTF8String(minor_data);
+            if(!bytes)
+                return NULL;
+
+            else if(!(minor_fname = strdup(PyBytes_AsString(bytes))))
+                return NULL;
+
+            Py_DECREF(bytes);
+        }
+        else if(PyList_Check(minor_data)) {
+            if(!PyList_Size(minor_data)) {
+                snprintf(error_txt, BUFSZ, "minor list must be non-empty");
+                goto error;
+            }
+        }
+        else {
+            snprintf(error_txt, BUFSZ, "minor data must be either a python list or a file path");
+            error_type = PyExc_TypeError;
+            goto error;
+        }
+    }
+
+    if(!params.opt_fname || !strlen(params.opt_fname)) {
+        snprintf(error_txt, BUFSZ, "optimal rulelist file must be a valid file path");
+        goto error;
+    }
+    if(!params.log_fname || !strlen(params.log_fname)) {
+        snprintf(error_txt, BUFSZ, "log file must be a valid file path");
+        goto error;
+    }
+    if (params.max_num_nodes < 0) {
+        snprintf(error_txt, BUFSZ, "maximum number of nodes must be positive");
+        goto error;
+    }
+    if (params.c < 0.0) {
+        snprintf(error_txt, BUFSZ, "regularization constant must be postitive");
+        goto error;
+    }
+    if (params.map_type > 2 || params.map_type < 0) {
+        snprintf(error_txt, BUFSZ, "symmetry-aware map must be (0|1|2)");
+        goto error;
+    }
+    if (params.curiosity_policy < 0 || params.curiosity_policy > 4) {
+        snprintf(error_txt, BUFSZ, "you must specify a curiosity type (0|1|2|3|4)");
+        goto error;
+    }
+
+    //printf("out_fname: %s\n", out_fname);
+
+    if(out_fname) {
+        if(rules_init(out_fname, &params.nrules, &params.nsamples, &params.rules, 1) != 0) {
+            snprintf(error_txt, BUFSZ, "could not load out file at path '%s'", out_fname);
+            goto error;
+        }
+
+        free(out_fname);
+    } else {
+        if(load_list(out_data, &params.nrules, &params.nsamples, &params.rules, 1) != 0)
+            return NULL;
+    }
+
+    int nsamples_chk;
+    if(label_fname) {
+        if(rules_init(label_fname, &params.nlabels, &nsamples_chk, &params.labels, 0) != 0) {
+            rules_free(params.rules, params.nrules, 1);
+            snprintf(error_txt, BUFSZ, "could not load label file at path '%s'", label_fname);
+            goto error;
+        }
+
+        free(label_fname);
+    } else {
+        if(load_list(label_data, &params.nlabels, &nsamples_chk, &params.labels, 0) != 0) {
+            rules_free(params.rules, params.nrules, 1);
+            return NULL;
+        }
+    }
+
+    int nmeta, nsamples_check;
+
+    params.meta = NULL;
+    if (minor_data) {
+        if(minor_fname) {
+            if(rules_init(minor_fname, &nmeta, &nsamples_check, &params.meta, 0) != 0) {
+                rules_free(params.rules, params.nrules, 1);
+                rules_free(params.labels, params.nlabels, 0);
+                snprintf(error_txt, BUFSZ, "could not load minority file at path '%s'", minor_fname);
+                goto error;
+            }
+
+            free(minor_fname);
+        } else {
+            if(load_list(minor_data, &nmeta, &nsamples_check, &params.meta, 0) != 0) {
+                rules_free(params.rules, params.nrules, 1);
+                rules_free(params.labels, params.nlabels, 0);
+                return NULL;
+            }
+        }
+    }
+
+    if(params.nlabels != 2) {
+        rules_free(params.rules, params.nrules, 1);
+        rules_free(params.labels, params.nlabels, 0);
+        rules_free(params.meta, nmeta, 0);
+
+        snprintf(error_txt, BUFSZ, "the number of labels in the label file must be 2, not %d", params.nlabels);
+        goto error;
+    }
+
+    double accuracy = run_corels(params);
+
+    rules_free(params.rules, params.nrules, 1);
+    rules_free(params.labels, params.nlabels, 0);
+
+    if(params.meta)
+        rules_free(params.meta, nmeta, 0);
+
+    return Py_BuildValue("d", accuracy);
+
+error:
+
+    PyErr_SetString(error_type, error_txt);
+
+    return NULL;
+}
+
+static PyMethodDef pycorelsMethods[] = {
+    {"run", (PyCFunction)pycorels_run, METH_VARARGS | METH_KEYWORDS },
+    {"tolist", (PyCFunction)pycorels_tolist, METH_VARARGS },
+    {"tofile", (PyCFunction)pycorels_tofile, METH_VARARGS },
+    {NULL, NULL, 0, NULL}
+};
+
+#if PY_MAJOR_VERSION > 2
+
+static struct PyModuleDef pycorelsModule = {
+    PyModuleDef_HEAD_INIT,
+    "pycorels",
+    "Python binding to CORELS algorithm",
+    -1,
+    pycorelsMethods
+};
+
+PyMODINIT_FUNC PyInit_pycorels(void)
+{
+    import_array();
+
+    return PyModule_Create(&pycorelsModule);
+}
+
+#else
+
+PyMODINIT_FUNC initpycorels(void)
+{
+    import_array();
+
+    Py_InitModule("pycorels", pycorelsMethods);
+}
+
+#endif

--- a/pycorels/setup.py
+++ b/pycorels/setup.py
@@ -1,0 +1,14 @@
+from distutils.core import setup, Extension
+import numpy as np
+
+pycorels = Extension('pycorels',
+                    sources = ['pycorels.c'],
+                    libraries = ['corels', 'gmpxx', 'gmp'],
+                    library_dirs = ['../src'],
+                    include_dirs = [np.get_include()],
+		            extra_compile_args = ["-DGMP"])
+
+setup (name = 'pycorels',
+       version = '0.1',
+       description = 'Python binding of CORELS algorithm',
+       ext_modules = [pycorels])

--- a/pycorels/utils.h
+++ b/pycorels/utils.h
@@ -1,0 +1,196 @@
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <gmp.h>
+
+#include "../src/rule.h"
+
+#define BUFSZ  512
+
+PyObject* fill_list(PyObject *obj, rule_t *rules, int start, int nrules, int nsamples)
+{
+    PyObject *vector, *tuple;
+
+    if(!obj) {
+        PyErr_SetString(PyExc_MemoryError, "List is null");
+        return NULL;
+    }
+
+    for(int i = 0; i < nrules; i++)
+    {
+#ifdef GMP
+        int leading_zeros = nsamples - mpz_sizeinbase(rules[i].truthtable, 2);
+        char* bits = malloc(nsamples + 1);
+
+        mpz_get_str(bits + leading_zeros, 2, rules[i].truthtable);
+
+        for(int j = 0; j < leading_zeros; j++)
+            bits[j] = 0;
+
+        for(int j = leading_zeros; j < nsamples; j++)
+            bits[j] = bits[j] - '0';
+
+        int num_bits = nsamples;
+#else
+        char* bits = malloc(nsamples + 1);
+
+        int nentry = (nsamples + BITS_PER_ENTRY - 1) / BITS_PER_ENTRY;
+        v_entry mask;
+        for(int j = 0; j < nentry; j++) {
+            mask = 1;
+
+            for(int k = 0; k < BITS_PER_ENTRY; k++) {
+                bits[j * BITS_PER_ENTRY + k] = !!(rules[i].truthtable[j] & mask);
+                mask <<= 1;
+            }
+        }
+
+        bits[nsamples] = '\0';
+
+        int num_bits = nsamples;
+#endif
+
+        //rule_print(rules, i, nsamples, 1);
+        //printf("%s\n", bits);
+
+        if(!(vector = PyArray_FromString(bits, num_bits, PyArray_DescrFromType(NPY_BOOL), -1, NULL))) {
+            PyErr_SetString(PyExc_ValueError, "Could not load bitvector");
+            Py_DECREF(obj);
+            return NULL;
+        }
+
+        free(bits);
+
+        if(!(tuple = Py_BuildValue("sO", rules[i].features, vector))) {
+            Py_DECREF(obj);
+            return NULL;
+        }
+
+        if(PyList_SetItem(obj, start + i, tuple) != 0) {
+            Py_XDECREF(tuple);
+            PyErr_SetString(PyExc_Exception, "Could not insert tuple into list");
+            Py_XDECREF(obj);
+            return NULL;
+        }
+    }
+
+    return obj;
+}
+
+int load_list(PyObject *list, int *nrules, int *nsamples, rule_t **rules_ret, int add_default_rule)
+{
+    rule_t* rules = NULL;
+
+    if(!PyList_Check(list)) {
+        PyErr_SetString(PyExc_TypeError, "Data must be a python list");
+        goto error;
+    }
+
+    Py_ssize_t list_len = PyList_Size(list);
+
+    int ntotal_rules = list_len + (add_default_rule ? 1 : 0);
+
+    rules = malloc(sizeof(rule_t) * ntotal_rules);
+    if(!rules) {
+        PyErr_SetString(PyExc_MemoryError, "Could not allocate rule array");
+        goto error;
+    }
+
+    int samples_cnt = 0;
+
+    PyObject* tuple;
+    PyObject* vector;
+    char* features;
+
+    int rule_idx = ntotal_rules - list_len;
+    for(Py_ssize_t i = 0; i < list_len; i++) {
+        if(!(tuple = PyList_GetItem(list, i)))
+            goto error;
+
+        if(!PyTuple_Check(tuple)) {
+            PyErr_SetString(PyExc_TypeError, "Array members must be tuples");
+            goto error;
+        }
+
+        if(!PyArg_ParseTuple(tuple, "sO", &features, &vector))
+            goto error;
+
+        int features_len = strlen(features);
+        rules[rule_idx].features = malloc(features_len + 1);
+        strcpy(rules[rule_idx].features, features);
+        //rule[rule_idx].features[features_len] = '\0';
+
+        rules[rule_idx].cardinality = 1;
+
+        if(!PyArray_Check(vector)) {
+            PyErr_SetString(PyExc_TypeError, "The second element of each tuple must be a numpy array");
+            goto error;
+        }
+
+        int type = PyArray_TYPE((PyArrayObject*)vector);
+        if(PyArray_NDIM((PyArrayObject*)vector) != 1 && (PyTypeNum_ISINTEGER(type) || PyTypeNum_ISBOOL(type))) {
+            PyErr_SetString(PyExc_TypeError, "Each rule truthable must be a 1-d array of integers or booleans");
+            goto error;
+        }
+
+        PyArrayObject* clean = (PyArrayObject*)PyArray_FromAny(vector, PyArray_DescrFromType(NPY_BYTE), 0, 0, NPY_ARRAY_CARRAY | NPY_ARRAY_ENSURECOPY | NPY_ARRAY_FORCECAST, NULL);
+        if(clean == NULL) {
+            PyErr_SetString(PyExc_Exception, "Could not cast array to byte carray");
+            goto error;
+        }
+
+        char* data = PyArray_BYTES(clean);
+        npy_intp b_len = PyArray_SIZE(clean);
+
+        for(npy_intp j = 0; j < b_len; j++)
+            data[j] = '0' + !!data[j];
+
+        data[b_len] = '\0';
+
+        if(ascii_to_vector(data, b_len, &samples_cnt, &rules[rule_idx].support, &rules[rule_idx].truthtable) != 0) {
+            PyErr_SetString(PyExc_Exception, "Could not load bit vector");
+            Py_DECREF(clean);
+            goto error;
+        }
+
+        Py_DECREF(clean);
+
+        rule_idx++;
+    }
+
+    if(add_default_rule) {
+        rules[0].support = samples_cnt;
+		rules[0].features = "default";
+		rules[0].cardinality = 0;
+		if (make_default(&rules[0].truthtable, samples_cnt) != 0) {
+            PyErr_SetString(PyExc_Exception, "Could not make default rule");
+		    goto error;
+        }
+    }
+
+    *nrules = ntotal_rules;
+    *rules_ret = rules;
+    *nsamples = samples_cnt;
+
+    return 0;
+
+error:
+    if(rules != NULL) {
+        for (int i = 1; i < rule_idx; i++) {
+            free(rules[i].features);
+#ifdef GMP
+            mpz_clear(rules[i].truthtable);
+#else
+            free(rules[i].truthtable);
+#endif
+        }
+        free(rules);
+    }
+    *rules_ret = NULL;
+    *nrules = 0;
+    *nsamples = 0;
+    return 1;
+}

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -1,4 +1,4 @@
-CFLAGS := -g -W -Wall -Wno-unused-parameter -I. -DGMP -O$(O)
+CFLAGS := -g -W -Wall -Wno-unused-parameter -fPIC -I. -DGMP -O$(O)
 
 ifneq (,$(filter $(shell uname -n),elaines-MacBook-Pro.local Nicholass-Air-5.local))
     LIBS := -L/usr/local/lib
@@ -28,12 +28,18 @@ CXX = g++ -std=c++11
 
 DEPSDIR := .deps
 
-CLEAN = corels *~ *.o *.so
+CLEAN = corels libcorels.so *~ *.o *.so
 
-all: corels
+all: corels libcorels.so
 
 corels: main.o corels.o pmap.o cache.o rulelib.o utils.o
 	$(CXX) $(CFLAGS) $^ -o $@ $(LDFLAGS) $(LIBS)
+
+libcorels.so: run.o params.o corels.o pmap.o cache.o rulelib.o utils.o
+	$(CXX) -shared  -Wl,-soname,$@ -o $@ $^
+
+run.o: run.cc $(DEPSDIR)/stamp
+	$(CXX) $(CFLAGS) $(DEPCFLAGS) -c $< -o $@
 
 main.o: main.cc $(DEPSDIR)/stamp
 	$(CXX) $(CFLAGS) $(DEPCFLAGS) -c $< -o $@
@@ -52,6 +58,9 @@ cache.o: cache.cc $(DEPSDIR)/stamp
 
 rulelib.o: rulelib.c $(DEPSDIR)/stamp
 	$(CC) $(CFLAGS) $(DEPCFLAGS) -c $< -o $@
+
+params.o: params.c $(DEPSDIR)/stamp
+	$(CXX) $(CFLAGS) $(DEPCFLAGS) -c $< -o $@
 
 $(DEPSDIR)/stamp:
 	mkdir -p $(dir $@)

--- a/src/params.c
+++ b/src/params.c
@@ -1,0 +1,23 @@
+#include "params.h"
+
+void set_default_params(run_params_t* out)
+{
+    out->opt_fname = (char*)D_OPT_FNAME;
+    out->log_fname = (char*)D_LOG_FNAME;
+    out->max_num_nodes = D_MAX_NUM_NODES;
+    out->c = D_C;
+    out->vstring = (char*)D_VSTRING;
+    out->curiosity_policy = D_CURIOSITY_POLICY;
+    out->map_type = D_MAP_TYPE;
+    out->freq = D_FREQ;
+    out->ablation = D_ABLATION;
+    out->calculate_size = D_CALCULATE_SIZE;
+    out->latex_out = D_LATEX_OUT;
+
+    out->nrules = 0;
+    out->nlabels = 0;
+    out->nsamples = 0;
+    out->rules = NULL;
+    out->labels = NULL;
+    out->meta = NULL;
+}

--- a/src/params.h
+++ b/src/params.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "rule.h"
+
+#define D_OPT_FNAME          "corels-opt.txt"
+#define D_LOG_FNAME          "corels.txt"
+#define D_MAX_NUM_NODES      10000
+#define D_C                  0.01
+#define D_VSTRING            "progress"
+#define D_CURIOSITY_POLICY   2
+#define D_MAP_TYPE           1
+#define D_FREQ               1000
+#define D_ABLATION           0
+#define D_CALCULATE_SIZE     0
+#define D_LATEX_OUT          0
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct run_params {
+    char* opt_fname;
+    char* log_fname;
+    int max_num_nodes;
+    double c;
+    char* vstring;
+    int curiosity_policy;
+    int map_type;
+    int freq;
+    int ablation;
+    int calculate_size;
+    int latex_out;
+
+    int nrules;
+    int nlabels;
+    int nsamples;
+    rule_t* rules;
+    rule_t* labels;
+    rule_t* meta;
+} run_params_t;
+
+void set_default_params(run_params_t* out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/pmap.hh
+++ b/src/pmap.hh
@@ -85,6 +85,7 @@ typedef std::unordered_map<captured_key, cap_val, captured_hash, cap_eq, track_a
 class PermutationMap {
     public:
         virtual size_t size() { return 0; }
+        virtual ~PermutationMap() { }
         virtual Node* insert (unsigned short new_rule,
                              size_t nrules, bool prediction, bool default_prediction, double lower_bound,
                              double objective, Node* parent, int num_not_captured, int nsamples, int len_prefix,

--- a/src/rule.h
+++ b/src/rule.h
@@ -168,6 +168,8 @@ int count_ones_vector(VECTOR, int);
 int rule_vector_equal(const VECTOR, const VECTOR, short, short);
 size_t rule_vector_hash(const VECTOR, short);
 
+int ascii_to_vector(char *, size_t, int *, int *, VECTOR *);
+
 /* Functions for the Scalable Baysian Rule Lists */
 double *predict(data_t *, pred_model_t *, params_t *);
 void ruleset_proposal(ruleset_t *, int, int *, int *, char *, double *);

--- a/src/rulelib.c
+++ b/src/rulelib.c
@@ -31,7 +31,6 @@
 
 
 /* Function declarations. */
-int ascii_to_vector(char *, size_t, int *, int *, VECTOR *);
 int make_default(VECTOR *, int);
 #define RULE_INC 100
 

--- a/src/run.cc
+++ b/src/run.cc
@@ -1,0 +1,158 @@
+#include <stdio.h>
+#include <iostream>
+#include <set>
+
+#include "queue.hh"
+#include "run.hh"
+
+#define BUFSZ 512
+
+NullLogger* logger;
+
+extern "C" {
+
+double run_corels (run_params_t params) {
+
+    std::set<std::string> verbosity;
+
+    const char *voptions = "rule|label|samples|progress|log|silent";
+
+    char *vopt = NULL;
+    char *vcopy = strdup(params.vstring);
+    while ((vopt = strsep(&vcopy, ",")) != NULL) {
+        if (!strstr(voptions, vopt)) {
+            fprintf(stderr, "verbosity options must be one or more of (%s), separated with commas (i.e. -v progress,log)\n", voptions);
+            return -1.0;
+        }
+        verbosity.insert(vopt);
+    }
+    free(vcopy);
+
+    if (verbosity.count("samples") && !(verbosity.count("rule") || verbosity.count("label"))) {
+        fprintf(stderr, "verbosity 'samples' option must be combined with at least one of (rule|label)\n");
+        return -1.0;
+    }
+    if (verbosity.size() > 2 && verbosity.count("silent")) {
+        fprintf(stderr, "verbosity 'silent' option must be passed without any additional verbosity parameters\n");
+        return -1.0;
+    }
+
+    if (verbosity.size() == 0) {
+        verbosity.insert("progress");
+    }
+
+    if (verbosity.count("silent")) {
+        verbosity.clear();
+    }
+
+    if (verbosity.count("log")) {
+        print_machine_info();
+    }
+
+    if (verbosity.count("rule")) {
+        printf("%d rules %d samples\n\n", params.nrules, params.nsamples);
+        rule_print_all(params.rules, params.nrules, params.nsamples);
+        printf("\n\n");
+    }
+
+    if (verbosity.count("label")) {
+        printf("Labels (%d) for %d samples\n\n", params.nlabels, params.nsamples);
+        rule_print_all(params.labels, params.nlabels, params.nsamples);
+        printf("\n\n");
+    }
+
+    if (verbosity.count("log")) {
+        logger = new Logger(params.c, params.nrules, 2, params.log_fname, params.freq);
+    } else {
+        logger = new NullLogger();
+        logger->setVerbosity(0);
+    }
+
+    double init = timestamp();
+    char run_type[BUFSZ];
+    Queue* q;
+    strcpy(run_type, "LEARNING RULE LIST via ");
+    char const *type = "node";
+    if (params.curiosity_policy == 1) {
+        strcat(run_type, "CURIOUS");
+        q = new Queue(curious_cmp, run_type);
+        type = "curious";
+    } else if (params.curiosity_policy == 2) {
+        strcat(run_type, "LOWER BOUND");
+        q = new Queue(lb_cmp, run_type);
+    } else if (params.curiosity_policy == 3) {
+        strcat(run_type, "OBJECTIVE");
+        q = new Queue(objective_cmp, run_type);
+    } else if (params.curiosity_policy == 4) {
+        strcat(run_type, "DFS");
+        q = new Queue(dfs_cmp, run_type);
+    } else {
+        strcat(run_type, "BFS");
+        q = new Queue(base_cmp, run_type);
+    }
+
+    PermutationMap* p;
+    if (params.map_type == 1) {
+        strcat(run_type, " Prefix Map\n");
+        PrefixPermutationMap* prefix_pmap = new PrefixPermutationMap;
+        p = (PermutationMap*) prefix_pmap;
+    } else if (params.map_type == 2) {
+        strcat(run_type, " Captured Symmetry Map\n");
+        CapturedPermutationMap* cap_pmap = new CapturedPermutationMap;
+        p = (PermutationMap*) cap_pmap;
+    } else {
+        strcat(run_type, " No Permutation Map\n");
+        NullPermutationMap* null_pmap = new NullPermutationMap;
+        p = (PermutationMap*) null_pmap;
+    }
+
+    CacheTree* tree = new CacheTree(params.nsamples, params.nrules, params.c, params.rules, params.labels, params.meta, params.ablation, params.calculate_size, type);
+    if (verbosity.count("progress"))
+        printf("%s", run_type);
+    // runs our algorithm
+    bbound(tree, params.max_num_nodes, q, p);
+
+    const tracking_vector<unsigned short, DataStruct::Tree>& r_list = tree->opt_rulelist();
+
+    double accuracy = 1.0 - tree->min_objective() + params.c*r_list.size();
+
+    if (verbosity.count("progress")) {
+        printf("final num_nodes: %zu\n", tree->num_nodes());
+        printf("final num_evaluated: %zu\n", tree->num_evaluated());
+        printf("final min_objective: %1.5f\n", tree->min_objective());
+        printf("final accuracy: %1.5f\n", accuracy);
+   }
+
+    print_final_rulelist(r_list, tree->opt_predictions(),
+                     params.latex_out, params.rules, params.labels, params.opt_fname);
+
+    if (verbosity.count("progress"))
+        printf("final total time: %f\n", time_diff(init));
+
+    logger->dumpState();
+    logger->closeFile();
+
+    if (verbosity.count("progress")) {
+        printf("\ndelete tree\n");
+    }
+    delete tree;
+
+    if (verbosity.count("progress")) {
+        printf("\ndelete symmetry-aware map\n");
+    }
+    delete p;
+
+    if (verbosity.count("progress")) {
+        printf("\ndelete priority queue\n");
+    }
+    delete q;
+
+    /*if (verbosity.count("progress")) {
+        printf("\ndelete logger\n");
+    }
+    delete logger;*/
+
+    return accuracy;
+}
+
+} // end extern C

--- a/src/run.hh
+++ b/src/run.hh
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "params.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double run_corels (run_params_t params);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This pull request adds a python binding to corels, under the folder pycorels. I also added a few new files to the src directory, which are there only to allow me to run corels easily from the python binding. Finally, I made a few changes to the makefile to added targets for the new run.cc and params.c files, and a target to compile the entire library into a shared object file (libcorels.so) which is used by pycorels. Please let me know if you think I should reorganize any part of it!