### PR TITLE
adjust log filename to use verbosity string

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     int freq = 1000;
     int ablation = 0;
     bool calculate_size = false;
-    char verbstr[BUFSZ];
+    char verbstr[32];
     verbstr[0] = '\0';
     /* only parsing happens here */
     while ((ch = getopt(argc, argv, "bsLc:p:v:n:r:f:a:u:")) != -1) {
@@ -192,9 +192,9 @@ int main(int argc, char *argv[]) {
     else
         meta = NULL;
 
-    char froot[BUFSZ];
-    char log_fname[BUFSZ+4];
-    char opt_fname[BUFSZ+8];
+    char froot[BUFSZ+32];
+    char log_fname[BUFSZ+4+32];
+    char opt_fname[BUFSZ+8+32];
     const char* pch = strrchr(argv[0], '/');
     _snprintf(froot, BUFSZ, "../logs/for-%s-%s%s-%s-%s-removed=%s-max_num_nodes=%d-c=%.7f-v=%s-f=%d",
             pch ? pch + 1 : "",
@@ -204,9 +204,9 @@ int main(int argc, char *argv[]) {
                 (use_captured_sym_map ? "with_captured_symmetry_map" : "no_pmap"),
             meta ? "minor" : "no_minor",
             ablation ? ((ablation == 1) ? "support" : "lookahead") : "none",
-            max_num_nodes, c, verbosity, freq);
-    snprintf(log_fname, BUFSZ+4, "%s.txt", froot);
-    snprintf(opt_fname, BUFSZ+8, "%s-opt.txt", froot);
+            max_num_nodes, c, verbstr, freq);
+    snprintf(log_fname, BUFSZ+4+32, "%s.txt", froot);
+    snprintf(opt_fname, BUFSZ+8+32, "%s-opt.txt", froot);
 
     int ret = 0;
 


### PR DESCRIPTION
This PR does two very simple things:
- it adjust BUFSZ again for the verbosity text representation
- uses the verbosity char buffer variable in the log file