### PR TITLE
Feature/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+
+language: cpp
+sudo: required
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-7
+
+install:
+  - which $CXX
+  - which $CC
+  - $CXX --version
+
+script:
+  - cd src 
+  - make 
+  - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,9 @@
 
 language: cpp
-sudo: required
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-7
+sudo: false
 
 install:
   - which $CXX
-  - which $CC
   - $CXX --version
 
 script:


### PR DESCRIPTION
This should enable a valid Travis setup for you.  You need to link you Travis id (create one if missing) to GitHub, then ask it to scan your GH repos, and to turn on `nlarusstone/corels`.  I usually keep all defaults and just move the slider from off to on:

![image](https://user-images.githubusercontent.com/673121/70649822-7f110680-1c13-11ea-8160-05ec48a0a719.png)

(that is at https://travis-ci.org/account/repositories using my Travis account via my GH id)