### PR TITLE
Feature/tracking optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
   matrix:
     #
     - INFO="with alloc track"
-      TRACKALLOC=-DTRACK_ALLOC
+      TRACKALLOC=1
     #
     - INFO="without alloc track"
       TRACKALLOC=

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,20 @@
 language: cpp
 sudo: false
 
+env:
+  matrix:
+    #
+    - INFO="with alloc track"
+      TRACKALLOC=-DTRACK_ALLOC
+    #
+    - INFO="without alloc track"
+      TRACKALLOC=
+      
 install:
   - which $CXX
   - $CXX --version
 
 script:
   - cd src 
-  - make 
+  - make ${TRACKALLOC}
   - ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
 
 script:
   - cd src 
-  - make ${TRACKALLOC}
+  - make
   - ./tests

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -5,6 +5,10 @@ ifndef NGMP
     LIBS += -L/usr/local/lib -lgmp
 endif
 
+ifdef TRACKALLOC
+    CFLAGS += -DTRACK_ALLOC
+endif
+
 CXXFLAGS := $(CFLAGS)
 
 CXX := g++ -std=c++11

--- a/src/alloc.h
+++ b/src/alloc.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <typeinfo>
 
+#if defined(TRACK_ALLOC)
 template <class T, DataStruct S>
 struct track_alloc {
     DataStruct data_struct = S;
@@ -30,3 +31,8 @@ bool operator!=(const track_alloc<T, S>& t1, const track_alloc<U, V>& t2) {
 }
 template<class T, DataStruct S>
 using tracking_vector = std::vector<T, track_alloc<T, S> >;
+
+#else
+template<class T, DataStruct S>
+using tracking_vector = std::vector<T, std::allocator<T> >;
+#endif

--- a/src/cache.h
+++ b/src/cache.h
@@ -50,7 +50,11 @@ class Node {
     }
 
   protected:
+#if defined(TRACK_ALLOC)
     std::map<unsigned short, Node*, std::less<unsigned short>, track_alloc<std::pair<const unsigned short, Node*>, DataStruct::Tree> > children_;
+#else
+    std::map<unsigned short, Node* > children_;
+#endif
     Node* parent_;
     double lower_bound_;
     double objective_;
@@ -142,8 +146,11 @@ class CacheTree {
 
     double min_objective_;
     tracking_vector<unsigned short, DataStruct::Tree> opt_rulelist_;
+#if defined(TRACK_ALLOC)
     std::vector<bool, track_alloc<bool, DataStruct::Tree> > opt_predictions_;
-
+#else
+    std::vector<bool> opt_predictions_;
+#endif
     rule_t *rules_;
     rule_t *labels_;
     rule_t *minority_;

--- a/src/pmap.h
+++ b/src/pmap.h
@@ -43,7 +43,11 @@ struct prefix_hash {
     }
 };
 
+#if defined(TRACK_ALLOC)
 typedef std::unordered_map<prefix_key, prefix_val, prefix_hash, prefix_eq, track_alloc<std::pair<const prefix_key, prefix_val>, DataStruct::Pmap> > PrefixMap;
+#else
+typedef std::unordered_map<prefix_key, prefix_val, prefix_hash, prefix_eq, std::allocator<std::pair<const prefix_key, prefix_val> > > PrefixMap;
+#endif
 
 /*
  * Represents captured vector using the VECTOR type defined in rule.h
@@ -80,7 +84,11 @@ struct captured_hash {
     }
 };
 
+#if defined(TRACK_ALLOC)
 typedef std::unordered_map<captured_key, cap_val, captured_hash, cap_eq, track_alloc<std::pair<const captured_key, cap_val>, DataStruct::Pmap> > CapturedMap;
+#else
+typedef std::unordered_map<captured_key, cap_val, captured_hash, cap_eq, std::allocator<std::pair<const captured_key, cap_val> > > CapturedMap;
+#endif
 
 class PermutationMap {
     public:

--- a/src/rule.h
+++ b/src/rule.h
@@ -97,7 +97,7 @@ typedef struct ruleset {
 	int n_rules;			/* Number of actual rules. */
 	int n_alloc;			/* Spaces allocated for rules. */
 	int n_samples;
-	ruleset_entry_t* rules;	/* Array of rules. */
+	ruleset_entry_t *rules;		/* Array of rules. */
 } ruleset_t;
 
 typedef struct params {

--- a/src/utils.h
+++ b/src/utils.h
@@ -372,12 +372,12 @@ class Logger : public NullLogger {
         if (K > _nrules)
             K = _nrules;
 
-         // sum_{j=0}^M Q_j sum_{k=1}^{K-j} (M - j)! / (M - j - k)!
+        // sum_{j=0}^M Q_j sum_{k=1}^{K-j} (M - j)! / (M - j - k)!
         mpz_set_ui(tot, _nrules - len_prefix);
         for(size_t k = (_nrules - len_prefix - 1); k >= (_nrules - len_prefix - K + 1); --k)
             mpz_addmul_ui(tot, tot, k);
 
-         // multiply by Qj
+        // multiply by Qj
         mpz_mul_ui(tot, tot, _state.prefix_lens[len_prefix]);
     }
     inline void addQueueElement(unsigned int len_prefix, double lower_bound, bool approx) override {
@@ -445,6 +445,7 @@ inline double time_diff(double t0) {
 #endif
 
 #include "alloc.h"
+
 /*
  * Prints the final rulelist that CORELS returns.
  * rulelist -- rule ids of optimal rulelist


### PR DESCRIPTION
This pull request adds conditional builds with and without allocation tracking.   We need to be able to build without it for older g++ compilers (as for example still being used at CRAN for the Windows; but also on various RHEL instances and similarly dated setups).   Given that we now have Travis CI support, I also added a simple build matrix to build with, and without.