### PR TITLE
add conditional support for R builds via -DR_BUILD

### DIFF
--- a/src/corels.cpp
+++ b/src/corels.cpp
@@ -3,6 +3,13 @@
 #include <iostream>
 #include <stdio.h>
 
+#if defined(R_BUILD)
+ #define STRICT_R_HEADERS
+ #include "R.h"
+ // textual substitution
+ #define printf Rprintf
+#endif
+
 Queue::Queue(std::function<bool(Node*, Node*)> cmp, char const *type)
     : q_(new q (cmp)), type_(type) {}
 

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -6,6 +6,13 @@
 #include "queue.h"
 #include "run.h"
 
+#if defined(R_BUILD)
+ #define STRICT_R_HEADERS
+ #include "R.h"
+ // textual substitution
+ #define printf Rprintf
+#endif
+
 #define BUFSZ 512
 
 NullLogger* logger = nullptr;
@@ -25,7 +32,11 @@ int run_corels_begin(double c, char* vstring, int curiosity_policy,
     char *vcopy_begin = vcopy;
     while ((vopt = strtok(vcopy, ",")) != NULL) {
         if (!strstr(voptions, vopt)) {
+            #if !defined(R_BUILD)
             fprintf(stderr, "verbosity options must be one or more of (%s)\n", voptions);
+            #else
+            REprintf("verbosity options must be one or more of (%s)\n", voptions);
+            #endif
             return -1;
         }
         verbosity.insert(vopt);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,13 @@
 #include <assert.h>
 #include <sstream>
 
+#if defined(R_BUILD)
+ #define STRICT_R_HEADERS
+ #include "R.h"
+ // textual substitution
+ #define printf Rprintf
+#endif
+
 std::string sizet_tostring(size_t v) {
     std::ostringstream ss;
     ss << v;


### PR DESCRIPTION
This PR changes four C++ source files by bringing in what the [RcppCorels package](https://github.com/eddelbuettel/rcppcorels) currently uses -- but with changes entirely conditional on a new `#define` called `R_BUILD` (name open to change if need be).

In essence, we do three things:

1. When building for R, use `Rprintf` not `printf` to be synchronised with R's input/output -- a CRAN Policy requirement.  This is also "cheap" as we just define a file-local `typedef`.

2. When building for R, use `REprintf` not `fprintf(stderr,...)`  for the same reason.  This currenly needs `#ifdef` logic.  We could use a header and a function `errorMessage()` (or alike) and switch one inside the header file.   But used in few places so probably ok as is.

3. When building for R, do not use `fputs()` or `fputc()` for the same reason -- so I just switched to `printf()` (which becomes `Rprintf()` per point 1).   Used sparingly and the performance impact should be immaterial.  If need be this could go to a header as well.

This concludes my set of PRs for alignment with the R implementation.