### PR TITLE
Enable unit tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 
 language: cpp
 sudo: false
+dist: bionic
 
 env:
   matrix:
@@ -16,6 +17,4 @@ install:
   - $CXX --version
 
 script:
-  - cd src 
-  - make
-  - ./tests
+  - cd src && make && ./tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,12 @@ language: cpp
 sudo: false
 dist: bionic
 
-env:
-  matrix:
-    #
-    - INFO="with alloc track"
-      TRACKALLOC=1
-    #
-    - INFO="without alloc track"
-      TRACKALLOC=
+jobs:
+  include:
+    - name: "with alloc track"
+      env: TRACKALLOC=1
+    - name: "without alloc track"
+      env: TRACKALLOC
       
 install:
   - which $CXX

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -15,7 +15,7 @@ CXX := g++ -std=c++11
 
 DEPSDIR := .deps
 
-CLEAN := corels *~ *.o *.so
+CLEAN := corels *~ *.o *.so tests
 
 all: corels tests
 


### PR DESCRIPTION
Updates Travis CI distribution to bionic giving us g++ 7.4.0 out of the box.  

Unit tests now run at end of build as well.

See https://travis-ci.org/github/eddelbuettel/corels/builds/697993165 and https://travis-ci.org/github/eddelbuettel/corels/builds/697992108 for the two builds from these two commits.